### PR TITLE
Make group filtering safer for upsert searches

### DIFF
--- a/cif/httpd/common.py
+++ b/cif/httpd/common.py
@@ -7,7 +7,7 @@ from base64 import b64encode
 VALID_FILTERS = {
     'indicator', 'itype', 'confidence', 'provider', 'limit', 'application', 'nolog', 'tags', 'days',
     'hours', 'groups', 'reporttime', 'cc', 'asn', 'asn_desc', 'rdata', 'firsttime', 'lasttime', 'region', 'id',
-    'portlist', 'protocol', 'tlp', 'sort', 'group'
+    'portlist', 'protocol', 'tlp', 'sort',
 }
 TOKEN_FILTERS = ['username', 'token']
 

--- a/cif/store/zelasticsearch/filters.py
+++ b/cif/store/zelasticsearch/filters.py
@@ -275,15 +275,7 @@ def filter_build(s, filters, token=None):
 
     s = filter_reporttime(s, q_filters)
 
-    # transform all other filters into term=
-    s = filter_terms(s, q_filters)
-
-    # indicator search/submit should mostly use singular 'group' field, but the cifsdk uses 
-    # groups (plural) for both indicators and tokens
-    if q_filters.get('group'):
-        q_filters['groups'] = q_filters.pop('group')
-        s = filter_groups(s, q_filters)
-    elif q_filters.get('groups'):
+    if q_filters.get('groups'):
         s = filter_groups(s, q_filters)
     else:
         if token and (not token.get('admin') or token.get('admin') == ''):
@@ -291,5 +283,8 @@ def filter_build(s, filters, token=None):
 
     if q_filters.get('tags'):
         s = filter_tags(s, q_filters)
+
+    # transform all other filters into term=
+    s = filter_terms(s, q_filters)
 
     return s


### PR DESCRIPTION
It dawns on me that in #1 I created an easily attackable group bypass in which someone does an indicator search against the api using URL params `groups = [groups_my_token_has_access_to]` and `group = secret_group_my_token_has_no_permissions_to` and the token authZ check would only verify the `groups` value, but later, the filter would swap in the `group` value, thus permitting a search against groups to which a token shouldn't have permissions. 

* fix the above scenario
* add tests for upsert matching on rdata